### PR TITLE
🚧 Use github action to build data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build data
+
+on: [push]
+
+jobs:
+  build:
+    name: Docker image build CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: 🏃 Small dataset
+        if: steps.extract_branch.outputs.branch != 'master' && steps.extract_branch.outputs.branch != 'dev'
+        run: make all-step0 recipe-run watch-run FILES_TO_PROCESS=deces-2020-m01.txt.gz STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY RECIPE_THREADS=2
+        env:
+          STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+      - name: 🏃 Run full
+        if: steps.extract_branch.outputs.branch == 'master' || steps.extract_branch.outputs.branch == 'dev'
+        run: make all-step0 recipe-run watch-run STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY RECIPE_THREADS=2
+        env:
+          STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,23 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - name: 🏃 Small dataset
-        if: steps.extract_branch.outputs.branch != 'master' && steps.extract_branch.outputs.branch != 'dev'
-        run: make all-step0 recipe-run watch-run FILES_TO_PROCESS=deces-2020-m01.txt.gz STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY RECIPE_THREADS=2
-        env:
-          STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
-          STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v2
       - name: 🏃 Run full
-        if: steps.extract_branch.outputs.branch == 'master' || steps.extract_branch.outputs.branch == 'dev'
-        run: make all-step0 recipe-run watch-run STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY RECIPE_THREADS=2
+        #if: steps.extract_branch.outputs.branch == 'master' || steps.extract_branch.outputs.branch == 'dev'
+        run: make all-step0 recipe-run watch-run STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY CHUNK_SIZE=5000 ES_THREADS=2 RECIPE_THREADS=2 ES_MEM=4000m
         env:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+          #- name: 🏃 Small dataset
+          #  if: steps.extract_branch.outputs.branch != 'master' && steps.extract_branch.outputs.branch != 'dev'
+          #  run: make all-step0 recipe-run watch-run FILES_TO_PROCESS=deces-2020-m01.txt.gz STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY RECIPE_THREADS=2
+          #  env:
+          #    STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          #    STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+          #- name: 🏃 Run full
+          #  if: steps.extract_branch.outputs.branch == 'master' || steps.extract_branch.outputs.branch == 'dev'
+          #  run: make all-step0 recipe-run watch-run STORAGE_ACCESS_KEY=$STORAGE_ACCESS_KEY STORAGE_SECRET_KEY=$STORAGE_SECRET_KEY RECIPE_THREADS=2
+          #  env:
+          #    STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          #    STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,22 +37,22 @@ before_script:
     fi
 
 script:
-  - git fetch && git describe --tags
-  - make config
-  - if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) ]]; then
-      make all FILES_TO_PROCESS=deces-2020-m01.txt.gz || travis_terminate 1;
-    fi
-  - if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) && ( "$TRAVIS_BRANCH" == "dev" ) ]]; then
-      make clean remote-all
-          GIT_BRANCH="$TRAVIS_BRANCH"
-          FILES_TO_PROCESS=deces-2020-m[0-1][0-9].txt.gz
-          CHUNK_SIZE=50000 ES_THREADS=10 RECIPE_THREADS=16 ES_MEM=24000m RECIPE_QUEUE=16 SCW_FLAVOR=GP1-M;
-    fi
-  - if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) && ( "$TRAVIS_BRANCH" == "master" ) ]]; then
-      make clean remote-all
-        GIT_BRANCH="$TRAVIS_BRANCH"
-        CHUNK_SIZE=75000 ES_THREADS=48 RECIPE_THREADS=60 ES_MEM=48000m RECIPE_QUEUE=64 SCW_FLAVOR=GP1-XL;
-    fi
+  #- git fetch && git describe --tags
+  #- make config
+  #- if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) ]]; then
+  #    make all FILES_TO_PROCESS=deces-2020-m01.txt.gz || travis_terminate 1;
+  #  fi
+  #- if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) && ( "$TRAVIS_BRANCH" == "dev" ) ]]; then
+  #    make clean remote-all
+  #        GIT_BRANCH="$TRAVIS_BRANCH"
+  #        FILES_TO_PROCESS=deces-2020-m[0-1][0-9].txt.gz
+  #        CHUNK_SIZE=50000 ES_THREADS=10 RECIPE_THREADS=16 ES_MEM=24000m RECIPE_QUEUE=16 SCW_FLAVOR=GP1-M;
+  #  fi
+  #- if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) && ( "$TRAVIS_BRANCH" == "master" ) ]]; then
+  #    make clean remote-all
+  #      GIT_BRANCH="$TRAVIS_BRANCH"
+  #      CHUNK_SIZE=75000 ES_THREADS=48 RECIPE_THREADS=60 ES_MEM=48000m RECIPE_QUEUE=64 SCW_FLAVOR=GP1-XL;
+  #  fi
 
 after_failure:
   - if [[ ( "$TRAVIS_PULL_REQUEST" == "false" ) && (( "$TRAVIS_BRANCH" == "dev" ) || ( "$TRAVIS_BRANCH" == "master" ))]]; then

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ ${GIT_BACKEND}:
 	@echo "export ES_NODES=${ES_NODES}" >> ${GIT_BACKEND}/artifacts
 	@echo "export PROJECTS=${PWD}/projects" >> ${GIT_BACKEND}/artifacts
 	@echo "export STORAGE_BUCKET=${STORAGE_BUCKET}" >> ${GIT_BACKEND}/artifacts
+	sed -i -E "s/backend: network backend-docker-check/backend: network #backend-docker-check/"  backend/Makefile
+	sed -i -E "s/export API_SECRET_KEY:=(.*)/export API_SECRET_KEY:=1234/"  backend/Makefile
+	sed -i -E "s/export ADMIN_PASSWORD:=(.*)/export ADMIN_PASSWORD:=1234ABC/"  backend/Makefile
+	sed -i -E "s/id(.*):=(.*)/id:=myid/"  backend/Makefile
 
 dev: config
 	@${MAKE} -C ${APP_PATH}/${GIT_BACKEND} elasticsearch backend frontend &&\


### PR DESCRIPTION
WIP

In order to run the build data process in github actions there are two main modifications:
* Don't use `cat /dev/urandom` in matchid-backend because it leads to an infinite loop inside the github runner. 
* Don't do `docker check backend`. I think because it thinks that the docker image doesn't exists in docker hub. I had the following error otherwise:
```
no previous build found for matchid/matchid-backend:0.2.0-0559ef
Makefile:235: recipe for target 'docker-check' failed
make[2]: *** [docker-check] Error 1
Makefile:313: recipe for target 'backend-docker-check' failed
make[1]: *** [backend-docker-check] Error 2
Makefile:111: recipe for target 'recipe-run' failed
make: *** [recipe-run] Error 2
````

I did a dirty patch 💩 after cloning matchid-backend in order to prove that github actions run. But I think there are better solutions for this.

~I also propose to do a full data prep in dev and master branches using github actions~ ça prend pas mal du temps, je suis à 10M en 2 heures :roll_eyes:  . Other branches will only use the small dataset, which runs in 3 minutes.