### PR TITLE
Fix: The support for using Y (years) and M (months) in np.timedelta64…

### DIFF
--- a/projects/deces-dataprep/recipes/deces_dataprep.yml
+++ b/projects/deces-dataprep/recipes/deces_dataprep.yml
@@ -96,8 +96,9 @@ recipes:
          select: DATE.*NORM
          format: "%Y%m%d"
       - exec:
+          # Year = 365.25 * 24 * 60 * 60 seconds
           - df['AGE_DECES'] = np.where(df['DATE_DECES'] > df['DATE_NAISSANCE'],
-            (df['DATE_DECES_NORM'] - df['DATE_NAISSANCE_NORM']).astype('<m8[Y]'),
+            ((df['DATE_DECES_NORM'] - df['DATE_NAISSANCE_NORM']).astype('timedelta64[s]').astype(int) / 31557600).round().astype(int),
             None)
           - df['DATE_NAISSANCE_NORM'] = df['DATE_NAISSANCE_NORM'].dt.strftime('%Y%m%d')
           - df['DATE_DECES_NORM'] = df['DATE_DECES_NORM'].dt.strftime('%Y%m%d')


### PR DESCRIPTION
… was removed in newer versions of NumPy because these units are not unambiguous - using seconds instead of Years

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accuracy in the `AGE_DECES` calculation by refining the method of converting date differences to years.
- **Documentation**
	- Added comments to clarify the new calculation basis for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->